### PR TITLE
13824 rewrite new zealand scraper

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -20,9 +20,9 @@ def datefrom(date)
   Date.parse(date)
 end
 
-
-url = 'https://www.parliament.nz/en/mps-and-electorates/members-of-parliament/'
-page = noko(url)
+base_url = 'https://www.parliament.nz'
+url      = "#{base_url}/en/mps-and-electorates/members-of-parliament/"
+page     = noko(url)
 
 added = 0
 page.xpath('//entry').each do |entry|

--- a/scraper.rb
+++ b/scraper.rb
@@ -13,7 +13,7 @@ require 'open-uri/cached'
 OpenURI::Cache.cache_path = '.cache'
 
 def noko(url)
-  Nokogiri::HTML(open(url).read) 
+  Nokogiri::HTML(open(url).read)
 end
 
 def datefrom(date)
@@ -21,7 +21,7 @@ def datefrom(date)
 end
 
 
-url = 'http://www.parliament.nz/en-nz/syndication?posting=/en-nz/mpp/mps/current/'
+url = 'https://www.parliament.nz/en/mps-and-electorates/members-of-parliament/'
 page = noko(url)
 
 added = 0
@@ -32,7 +32,7 @@ page.xpath('//entry').each do |entry|
   mp = noko(mp_url)
   body = mp.css('div.contentBody')
 
-  data = { 
+  data = {
     id: entry.xpath('id').text,
     name: body.css('a[href^=mailto]').text,
     sort_name: entry.xpath('title').text.strip,
@@ -51,5 +51,3 @@ page.xpath('//entry').each do |entry|
   ScraperWiki.save_sqlite([:name, :term], data)
 end
 puts "  Added #{added} members"
-
-

--- a/scraper.rb
+++ b/scraper.rb
@@ -32,20 +32,20 @@ page.css('.list__row').each do |entry|
   body   = mp.css('div.koru-side-holder')
 
   data = {
-    id: entry.xpath('id').text,
-    name: body.css('a[href^=mailto]').text,
-    sort_name: entry.xpath('title').text.strip,
-    party: entry.xpath('content').text.strip.split(/, /).first,
-    area: entry.xpath('content').text.strip.split(/, /).last,
-    photo: body.css('td.image img/@src').text,
-    email: body.css('a[href^=mailto]/@href').text.gsub('mailto:',''),
-    facebook: body.css('div.infoTiles a[@href*="facebook"]/@href').text,
-    twitter: body.css('div.infoTiles a[@href*="twitter"]/@href').text,
+    id: mp_url.split("/")[-2],
+    name: body.css("div[role='main']").css('h1').inner_text,
+    sort_name: link.inner_text.strip,
+    party: body.css('.informaltable td')[1].inner_text,
+    area:  body.css('.informaltable td')[0].inner_text,
+    photo: body.css('.document-panel__img img/@src').last.text,
+    email: body.css('a.square-btn').attr('href').inner_text.gsub('mailto:',''),
+    facebook: body.css('div.related-links__item a[@href*="facebook"]/@href').text,
+    twitter:  body.css('div.related-links__item a[@href*="twitter"]/@href').text,
     term: 51,
     source: mp_url,
   }
-  data[:photo].prepend 'http://www.parliament.nz/' unless data[:photo].nil? or data[:photo].empty?
-  # puts data
+  data[:photo].prepend(base_url) unless data[:photo].nil? or data[:photo].empty?
+
   added += 1
   ScraperWiki.save_sqlite([:name, :term], data)
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -25,12 +25,11 @@ url      = "#{base_url}/en/mps-and-electorates/members-of-parliament/"
 page     = noko(url)
 
 added = 0
-page.xpath('//entry').each do |entry|
-  id = entry.xpath('id').text
-  mp_url = entry.xpath('link/@href').text
-
-  mp = noko(mp_url)
-  body = mp.css('div.contentBody')
+page.css('.list__row').each do |entry|
+  link   = entry.css('.theme__link')
+  mp_url = link.attr('href').inner_text.prepend(base_url)
+  mp     = noko(mp_url)
+  body   = mp.css('div.koru-side-holder')
 
   data = {
     id: entry.xpath('id').text,


### PR DESCRIPTION
Updates scraper according to the new dedicated member pages.
Candidates have been reduced from 123 (original number) to 121.
![121](https://cloud.githubusercontent.com/assets/2157089/16766800/10c3eb40-4834-11e6-9d29-81fe76a442fd.png)

Checked sqlite file:

``` sql
sqlite> SELECT * FROM data LIMIT 1;
51MP2691|Hon Amy Adams|Adams, Amy|National Party|Selwyn|https://www.parliament.nz/media/2061/adams-amy.C2zLkg.jpg|amy.adams@parliament.govt.nz|https://www.facebook.com/MPAmyAdams |https://twitter.com/amyadamsMP |51|https://www.parliament.nz/en/mps-and-electorates/members-of-parliament/document/51MP2691/adams-amy
```

Fingers crossed, I think everything works.

Closes everypolitician/everypolitician-data#13824
@tmtmtmtm 
