### PR TITLE
Update scraper adding a loop to scrape the term dates

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -43,7 +43,8 @@ page.css('.list__row').each do |entry|
     term: 51,
     source: mp_url,
   }
-  data[:photo].prepend(base_url) unless data[:photo].nil? or data[:photo].empty?
+
+  data[:photo] = URI.join(mp_url, data[:photo]).to_s unless data[:photo].to_s.empty?
 
   added += 1
   ScraperWiki.save_sqlite([:name, :term], data)

--- a/scraper.rb
+++ b/scraper.rb
@@ -16,7 +16,8 @@ def noko(url)
 end
 
 def datefrom(date)
-  Date.parse(date)
+  return if date.to_s.strip.empty?
+  Date.parse(date).to_s
 end
 
 base_url = 'https://www.parliament.nz'
@@ -31,22 +32,29 @@ page.css('.list__row').each do |entry|
   body   = mp.css('div.koru-side-holder')
 
   data = {
-    id: mp_url.split("/")[-2],
-    name: body.css("div[role='main']").css('h1').inner_text,
-    sort_name: link.inner_text.strip,
-    party: body.css('.informaltable td')[1].inner_text,
-    area:  body.css('.informaltable td')[0].inner_text,
-    photo: body.css('.document-panel__img img/@src').last.text,
-    email: body.css('a.square-btn').attr('href').inner_text.gsub('mailto:',''),
-    facebook: body.css('div.related-links__item a[@href*="facebook"]/@href').text,
-    twitter:  body.css('div.related-links__item a[@href*="twitter"]/@href').text,
-    term: 51,
-    source: mp_url,
+    id:         mp_url.split("/")[-2],
+    name:       body.css("div[role='main']").css('h1').inner_text,
+    sort_name:  link.inner_text.strip,
+    photo:      body.css('.document-panel__img img/@src').last.text,
+    email:      body.css('a.square-btn').attr('href').inner_text.gsub('mailto:',''),
+    facebook:   body.css('div.related-links__item a[@href*="facebook"]/@href').text,
+    twitter:    body.css('div.related-links__item a[@href*="twitter"]/@href').text,
+    term:       51,
+    source:     mp_url
   }
 
   data[:photo] = URI.join(mp_url, data[:photo]).to_s unless data[:photo].to_s.empty?
 
+  body.css('.informaltable tr').each do |row|
+    data[:area]       = row.css('td')[0].inner_text
+    data[:party]      = row.css('td')[1].inner_text
+    data[:start_date] = datefrom(row.css('td')[2].inner_text.split("-").first)
+    data[:end_date]   = datefrom(row.css('td')[2].inner_text.split("-").last)
+
+    ScraperWiki.save_sqlite([:id, :term, :start_date], data)
+  end
+
   added += 1
-  ScraperWiki.save_sqlite([:name, :term], data)
+
 end
 puts "  Added #{added} members"

--- a/scraper.rb
+++ b/scraper.rb
@@ -5,7 +5,6 @@ require 'scraperwiki'
 require 'nokogiri'
 require 'date'
 require 'open-uri'
-require 'date'
 
 require 'colorize'
 require 'pry'


### PR DESCRIPTION
This PR updates the scraper so that it scrapes start and end dates from the table, because they were there in the previous page and we were scraping them, but we lost them when the page layout changed.

Seeing comment https://github.com/everypolitician-scrapers/new-zealand-parliament/pull/2#discussion_r71033090, I guess that part will have to wait for a new PR.
