### PR TITLE
Migrate to Scraped

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 # specified here will be installed and made available to your morph.io scraper.
 # Find out more: https://morph.io/documentation/ruby
 
-ruby '2.0.0'
+ruby '2.3.1'
 
 source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
@@ -11,5 +11,6 @@ gem 'nokogiri'
 gem 'open-uri-cached'
 gem 'pry'
 gem 'rubocop'
+gem 'scraped', github: 'everypolitician/scraped'
 gem 'scraped_page_archive'
 gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby', branch: 'morph_defaults'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/everypolitician/scraped.git
+  revision: aabdf259f6cc2f746b50352e078a9141450e8d6e
+  specs:
+    scraped (0.1.0)
+      field_serializer
+      nokogiri
+      require_all
+
+GIT
   remote: https://github.com/openaustralia/scraperwiki-ruby.git
   revision: fc50176812505e463077d5c673d504a6a234aa78
   branch: morph_defaults
@@ -16,6 +25,7 @@ GEM
     coderay (1.1.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    field_serializer (0.2.0)
     git (1.3.0)
     hashdiff (0.3.1)
     httpclient (2.6.0.1)
@@ -33,6 +43,7 @@ GEM
       slop (~> 3.4)
     public_suffix (2.0.4)
     rainbow (2.1.0)
+    require_all (1.3.3)
     rubocop (0.45.0)
       parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
@@ -66,11 +77,12 @@ DEPENDENCIES
   open-uri-cached
   pry
   rubocop
+  scraped!
   scraped_page_archive
   scraperwiki!
 
 RUBY VERSION
-   ruby 2.0.0p648
+   ruby 2.3.1p112
 
 BUNDLED WITH
    1.13.6


### PR DESCRIPTION
Rewrite scraper using 'Scraped' library

## Note to Reviewer

Ideally the two places where we're using `URI.join` will disappear with the new release of Scraped, which will give us built-in decorators for ensuring these are already absolute URLs by the time the Page classes kick in…